### PR TITLE
Use __file__ as the basis for module search path

### DIFF
--- a/toward
+++ b/toward
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys, os, getopt, glob
-scriptPath = os.path.realpath(os.path.dirname(sys.argv[0]))
+scriptPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(scriptPath + os.sep + 'lib')
 from project import Project
 

--- a/twee
+++ b/twee
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys, os, getopt, glob
-scriptPath = os.path.realpath(os.path.dirname(sys.argv[0]))
+scriptPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(scriptPath + os.sep + 'lib')
 from tiddlywiki import TiddlyWiki
 

--- a/untwee
+++ b/untwee
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 import sys, os
-sys.path.append(os.getcwd() + os.sep + 'lib')
+scriptPath = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(scriptPath + os.sep + 'lib')
 from tiddlywiki import TiddlyWiki
 
 def usage():


### PR DESCRIPTION
I had run into a problem that twee (and the other bins) couldn't find their module when called from symlinks rather than the actual binaries, since argv[0] didn't contain the actual path. In my case I'd installed twee to another location, then symlinked the binaries into /usr/local/bin.

Basing the path on `__file__` instead ensures that the correct path will be found regardless of where the tool's invoked from.
