### PR TITLE
Fix for Mac OSX (and others?)

### DIFF
--- a/twee
+++ b/twee
@@ -84,7 +84,7 @@ def main (argv):
 	
 	# the tiddlers
 	
-	print tw.toHtml()
+	print tw.toHtml(scriptPath)
 	
 	# plugins
 	


### PR DESCRIPTION
Twee doesn't work on Mac OSX in the Terminal. With this modification, it will.

WARNING: I only tested in Mac OSX 10.7. It could very well break stuff on other platforms.

I've found the fix there: https://groups.google.com/d/msg/tweecode/ik1ppjTomGY/5Xc0g-LeRVMJ
