### PR TITLE
Fix Untwee Regex Issue

### DIFF
--- a/lib/tiddlywiki.py
+++ b/lib/tiddlywiki.py
@@ -135,10 +135,11 @@ class TiddlyWiki:
 			
 	def addHtml (self, source):
 		"""Adds HTML source code to this TiddlyWiki."""
-		divs_re = re.compile(r'<div id="storeArea">(.*)</div>\s*</html>',
-												 re.DOTALL)
+		divs_re = re.compile(
+			r'<div id="storeArea"(.*)</html>',
+			re.DOTALL
+		)
 		divs = divs_re.search(source)
-
 		if divs:
 			for div in divs.group(1).split('<div'):
 				self.addTiddler(Tiddler('<div' + div, 'html'))

--- a/untwee
+++ b/untwee
@@ -16,7 +16,10 @@ def main (argv):
 
 	file = open(argv[0])
 	tw = TiddlyWiki()
-	tw.addHtml(file.read())
+	data = file.read()
+	# print data
+	tw.addHtml(data)
+	# print tw
 	print tw.toTwee()
 	
 

--- a/untwee
+++ b/untwee
@@ -19,7 +19,6 @@ def main (argv):
 	data = file.read()
 	# print data
 	tw.addHtml(data)
-	# print tw
 	print tw.toTwee()
 	
 


### PR DESCRIPTION
Fixes[ an issue ](https://github.com/tweecode/twee/issues/14)where some Twine 2 games cannot be untwee-ed (decompiled into Twine 2). 